### PR TITLE
Github issue resolution

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -11,10 +11,10 @@ from typing import List, Optional
 import torch
 import uvicorn
 
-from scheduler import Scheduler
-from executor import Executor
-from telemetry import TelemetryCollector
-from models.simple_model import create_model
+from server.scheduler import Scheduler
+from server.executor import Executor
+from server.telemetry import TelemetryCollector
+from server.models.simple_model import create_model
 
 
 # Request/Response models
@@ -102,7 +102,7 @@ async def health_check():
     return info
 
 
-@app.post("/predict", response_model=InferenceResponse)
+@app.post("/predict", response_model=InferenceResponse, response_model_exclude_none=True)
 async def predict(request: InferenceRequest):
     """
     Main inference endpoint.


### PR DESCRIPTION
Fixes a failing test by excluding `None` values from the `/predict` endpoint response and correcting import paths.

The test failed because `gpu_memory_mb` was `None` on CPU-only environments but still serialized as `{"gpu_memory_mb": null}`. The test then attempted to compare this `None` value with an integer, causing a `TypeError`. Excluding `None` values ensures `gpu_memory_mb` is only present when a GPU is available. Relative imports were also corrected to absolute imports to resolve module dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-7382f43e-a056-4eee-8171-535bb64281a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7382f43e-a056-4eee-8171-535bb64281a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Imports:** Replace relative imports with absolute `server.*` imports for `Scheduler`, `Executor`, `TelemetryCollector`, and `create_model`.
> - **API behavior:** Update `POST /predict` to `response_model_exclude_none=True`, omitting fields like `gpu_memory_mb` when not applicable (e.g., CPU-only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df344fa7e05a1493f951e347a7c3c8b721eb5108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->